### PR TITLE
Update xmldom dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "tslib": "^2.0.1",
-    "xmldom": "^0.3.0",
+    "xmldom": "^0.4.0",
     "xpath.js": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In my particular case the need to update arises from the fact that closure compiler refuses to compile using xmldom 0.3.0 due to a problem that is fixed in xmldom 0.4.0.