### PR TITLE
Namespace-indepent GetElementById

### DIFF
--- a/src/xml_object.ts
+++ b/src/xml_object.ts
@@ -46,11 +46,11 @@ export class XmlObject implements IXmlSerializable {
         }
         if (xel == null) {
             // search an "undefined" ID
-            xel = SelectSingleNode(node, `//*[@Id='${idValue}']`);
+            xel = SelectSingleNode(node, `//*[@*[local-name()='Id']='${idValue}']`);
             if (xel == null) {
-                xel = SelectSingleNode(node, `//*[@ID='${idValue}']`);
+                xel = SelectSingleNode(node, `//*[@*[local-name()='ID']='${idValue}']`);
                 if (xel == null) {
-                    xel = SelectSingleNode(node, `//*[@id='${idValue}']`);
+                    xel = SelectSingleNode(node, `//*[@*[local-name()='id']='${idValue}']`);
                 }
             }
         }


### PR DESCRIPTION
I was using XMLDSIGjs to validate a specific XML file [see here](https://gist.github.com/ledgitbe/4082121c32c5efb388f7ee5249acc216)

The code path inside XMLDSIGjs is as follows:

1. `SignedXml` class
2. `Verify()`
3. `VerifyReferences()` [see here](https://github.com/PeculiarVentures/xmldsigjs/blob/71e66d3fede1c768a112330ac852a4d2a1c2fd49/src/signed_xml.ts#L208)
4. `DigestReference()` [see here](https://github.com/PeculiarVentures/xmldsigjs/blob/71e66d3fede1c768a112330ac852a4d2a1c2fd49/src/signed_xml.ts#L328)
5. `XmlCore.XmlObject.GetElementById()` [called here](https://github.com/PeculiarVentures/xmldsigjs/blob/71e66d3fede1c768a112330ac852a4d2a1c2fd49/src/signed_xml.ts#L389)

Continuing in XmlCore:
6. `GetElementById()` : It tries to find an element using Xpath [see here](https://github.com/PeculiarVentures/xml-core/blob/144c3eee40ef2fa8487ed455acc1534a58f48d6c/src/xml_object.ts#L49)

It was not able to get the following element:
`  <wstxns8:Body wsu:Id="id-1-9aa320963c34df6165073aa90a42581a"
    xmlns:wstxns8="http://schemas.xmlsoap.org/soap/envelope/"
    xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">`

I reasoned that the namespace of the Id attribute was the cause, so I changed `GetElementById()` to allow looking up elements by id regardless of any namespace on the id attribute.

I don't know enough about the XMLDSIGjs and XmlCode codebase or XML files in general to judge whether this is a good approach, so do with this as you see fit. I'm curious to hear your thoughts on this.

In any case, "it works" for me and I'm able to verify the file now by supplying the CryptoKey from the SPKI in the embedded certificate in the XML file.